### PR TITLE
[RFC] Sidestep `File.read!` on every svg render

### DIFF
--- a/lib/qr_code/render/svg.ex
+++ b/lib/qr_code/render/svg.ex
@@ -134,7 +134,7 @@ defmodule QRCode.Render.Svg do
   defp put_image({base64_encoded_image_binary, mime_type_atom, size})
        when is_binary(base64_encoded_image_binary) and 0 < size do
     mime_type = mime_type_atom |> to_string() |> valid_mime_type()
-    href = build_encoded_binary(encoded_image, mime_type)
+    href = build_encoded_binary(base64_encoded_image_binary, mime_type)
 
     {:image,
      %{

--- a/lib/qr_code/render/svg_settings.ex
+++ b/lib/qr_code/render/svg_settings.ex
@@ -3,7 +3,17 @@ defmodule QRCode.Render.SvgSettings do
   Settings structure for Svg.
   """
 
-  @type image :: ExMaybe.t({binary(), pos_integer()})
+  @type image_file_path :: binary()
+  @type base64_encoded_image_binary :: binary()
+  @type mime_type_atom :: :svg | :png | :jpg | :jpeg
+  @type image_size :: pos_integer()
+
+  @type image ::
+          ExMaybe.t(
+            {image_file_path(), image_size()}
+            | {base64_encoded_image_binary(), mime_type_atom(), image_size()}
+          )
+
   @type background_opacity :: ExMaybe.t(float())
   @type background_color :: String.t() | tuple
   @type qrcode_color :: String.t() | tuple


### PR DESCRIPTION
This library is very nice. It is a joy to use :)

I was playing with custom SVGs and found the `image` implementation a bit awkward.

If I already have my image as an encoded binary then I want to be able to use it.

Moreover, the "baked-in" `File.read!` is too particular. It assumes  a bit too much.

So this is a very simple attempt to start opening it up. What I have done is very strange and ugly. I was trying to change as little as possible of the existing code.

If anybody has any thoughts/insight/advice/suggestions, please write them here. I promise I will be nice and I will try to make the `image` prop useful and easy for everyone.