### PR TITLE
Allow flatten render for the svg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ tags
 .projections.json
 
 .elixir_ls/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ There are several options to change the appearance of svg or png:
 | background_opacity | nil or 0.0 <= x <= 1.0 | nil           | sets background opacity of svg      |
 | background_color   | string or {r, g, b}    | "#ffffff"     | sets background color of svg        |
 | qrcode_color       | string or {r, g, b}    | "#000000"     | sets color of QR                    |
+| flatten            | boolean                | false         | renders path data instead of rects  |                                     |
 | image              | {string, size} or nil  | nil           | puts the image to the center of svg |
 | structure          | :minify or :readable   | :minify       | minifies or makes readable svg file |
 ```

--- a/lib/qr_code/render/svg_settings.ex
+++ b/lib/qr_code/render/svg_settings.ex
@@ -17,6 +17,7 @@ defmodule QRCode.Render.SvgSettings do
   @type background_opacity :: ExMaybe.t(float())
   @type background_color :: String.t() | tuple
   @type qrcode_color :: String.t() | tuple
+  @type flatten :: boolean()
   @type structure :: :minify | :readable
 
   @type t :: %__MODULE__{
@@ -25,6 +26,7 @@ defmodule QRCode.Render.SvgSettings do
           background_opacity: background_opacity,
           background_color: background_color,
           qrcode_color: qrcode_color,
+          flatten: flatten,
           structure: structure
         }
 
@@ -33,5 +35,6 @@ defmodule QRCode.Render.SvgSettings do
             background_opacity: nil,
             background_color: "#ffffff",
             qrcode_color: "#000000",
+            flatten: false,
             structure: :minify
 end


### PR DESCRIPTION
Added a new option `flatten` to the `%SvgSettings{}`. 
This will allow `<path d="<data>" />` to be rendered.

## Benefits:

1. Smaller files / markup - 6KB (flatten) vs 14KB (normal) for a 30 chars length input;
2. Prevent "spacing" glitch that appear between the `rects` due to pixel density (happens when svg is resized).

Normal - 14KB  | Flatten - 6KB
--------------|--------------
<img width="333" src="https://github.com/user-attachments/assets/5a3b7e8e-4760-40c6-af28-fb267c02b400" /> |  <img  width="333" src="https://github.com/user-attachments/assets/c379d0f3-eb70-4deb-b50d-1d8627d31a93" />

## Glitch preview

![glitch_preview](https://github.com/user-attachments/assets/510d7e2b-a0b4-4cc8-84b2-d99ab4bb9822)


