### PR TITLE
Fix dialyzer error about missing .dialyzer_ignore.exs file

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,1 +1,0 @@
-Expression produces a value of type 'ok' | {'error',_}, but this value is unmatched

--- a/mix.exs
+++ b/mix.exs
@@ -82,7 +82,6 @@ defmodule QRCode.MixProject do
     [
       plt_add_apps: [:mix, :ex_unit],
       plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
-      ignore_warnings: "dialyzer.ignore-warnings",
       flags: [
         :error_handling,
         :no_opaque


### PR DESCRIPTION
Hello! This should fix the following error in the CI (that's currently failing on `master`)
```
(File.Error) could not read file stats ".dialyzer_ignore.exs": no such file or directory
```

It looks like running dialyzer succeeds without ignoring the warnings that were in `dialyzer.ignore-warnings` so I just removed the `:ignore_warnings` section and that file 🧹 

It works locally for me at least, it should work in the CI...?