### PR TITLE
Make styling easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ There are several options to change the appearance of svg or png:
 | Option             | Type                   | Default value | Description                         |
 |--------------------|------------------------|---------------|-------------------------------------|
 | scale              | positive integer       | 10            | changes size of rendered QR code    |
+| class              | string                 | ""            | add a CSS class to the svg tag      |
+| scale              | positive integer       | 10            | changes size of rendered QR code    |
 | background_opacity | nil or 0.0 <= x <= 1.0 | nil           | sets background opacity of svg      |
 | background_color   | string or {r, g, b}    | "#ffffff"     | sets background color of svg        |
 | qrcode_color       | string or {r, g, b}    | "#000000"     | sets color of QR                    |

--- a/lib/qr_code/render/svg.ex
+++ b/lib/qr_code/render/svg.ex
@@ -71,15 +71,16 @@ defmodule QRCode.Render.Svg do
            qrcode_color: qc,
            flatten: flatten,
            scale: scale,
-           structure: structure
+           structure: structure,
+           class: class
          }
        ) do
     {:svg,
      %{
        xmlns: xmlns,
        xlink: xlink,
-       width: rank_matrix * scale,
-       height: rank_matrix * scale
+       viewBox: "0 0 #{rank_matrix * scale} #{rank_matrix * scale}",
+       class: class
      }, [background_rect(bg, bg_tr), body_type(body, qc, flatten), put_image(image)]}
     |> XmlBuilder.generate(format: format(structure))
   end

--- a/lib/qr_code/render/svg_settings.ex
+++ b/lib/qr_code/render/svg_settings.ex
@@ -21,6 +21,7 @@ defmodule QRCode.Render.SvgSettings do
   @type structure :: :minify | :readable
 
   @type t :: %__MODULE__{
+          class: String.t(),
           scale: integer,
           image: image,
           background_opacity: background_opacity,
@@ -36,5 +37,6 @@ defmodule QRCode.Render.SvgSettings do
             background_color: "#ffffff",
             qrcode_color: "#000000",
             flatten: false,
-            structure: :minify
+            structure: :minify,
+            class: ""
 end


### PR DESCRIPTION
The current implementation makes it challenging to style the SVG after generation.

This PR

- Switches to applying the sizing view `viewBox`, which makes subsequent CSS based styling easier
- Adds a `class` property to the SVG settings struct, allowing direct application of CSS classes too

It does remove the presence of `width` and `height` from the generated SVG, so if accepted this might be considered a breaking change