### PR TITLE
Fix range warning on Elixir 1.18

### DIFF
--- a/lib/qr_code/placement.ex
+++ b/lib/qr_code/placement.ex
@@ -180,7 +180,7 @@ defmodule QRCode.Placement do
   end
 
   defp fill_matrix_by_message(matrix, size, message) do
-    (size - 1)..7
+    (size - 1)..7//-1
     |> Enum.take_every(2)
     |> Enum.concat([5, 3, 1])
     |> Enum.map_reduce({matrix, message}, fn col, acc ->

--- a/test/placement_test.exs
+++ b/test/placement_test.exs
@@ -143,7 +143,7 @@ defmodule PlacementTest do
     size = 4 * version + 16
 
     {:ok, [hd | rest]} =
-      size..7
+      size..7//-1
       |> Enum.take_every(2)
       |> Enum.concat([5, 3, 1])
       |> Enum.reverse()


### PR DESCRIPTION
Elixir 1.18 now warns when you create a range with a negative step without explicitly providing the step.

```
Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
```

This PR updates a couple of occurrences of this to explicitly provide a step of `-1`.

One of this library's dependencies, `matrix_reloaded`, also emits these warnings, but I did not attempt to handle those.