### PR TITLE
viewbox for the SVG renderer makes for happy styling

### DIFF
--- a/lib/qr_code/render/svg.ex
+++ b/lib/qr_code/render/svg.ex
@@ -76,12 +76,16 @@ defmodule QRCode.Render.Svg do
            structure: structure
          }
        ) do
+    width = rank_matrix * scale
+    height = width
+
     {:svg,
      %{
        xmlns: xmlns,
        xlink: xlink,
-       width: rank_matrix * scale,
-       height: rank_matrix * scale
+       width: width,
+       height: height,
+       viewbox: "0 0 #{width} #{height}"
      }, [background_rect(bg, bg_tr), body_type(body, qc, flatten), put_image(image)]}
     |> XmlBuilder.generate(format: format(structure))
   end

--- a/test/svg_test.exs
+++ b/test/svg_test.exs
@@ -75,6 +75,18 @@ defmodule SvgTest do
       assert Regex.match?(@rgx_svg_attrs, rv)
     end
 
+    test "file should contain width and height and a matching viewbox" do
+      rv =
+        @dst_to_file
+        |> File.stream!()
+        |> Stream.take(2)
+        |> Enum.at(0)
+
+      assert [_, width] = Regex.run(~r/width="(\d+)"/, rv)
+      assert [_, height] = Regex.run(~r/height="(\d+)"/, rv)
+      assert rv =~ "viewbox=\"0 0 #{width} #{height}\""
+    end
+
     test "file should not contain background opacity" do
       rv =
         @dst_to_file


### PR DESCRIPTION
As explained in https://github.com/iodevs/qr_code/issues/61, having a viewbox
attribute in the svg makes the svg resizeable without cutting is content. This
ensures the attribute is set, and matches the width/height already defines, and
adds tests.
