### PR TITLE
Fix quiet_space=0 case

### DIFF
--- a/lib/qr_code/matrix_helper.ex
+++ b/lib/qr_code/matrix_helper.ex
@@ -5,21 +5,18 @@ defmodule QRCode.MatrixHelper do
   alias MatrixReloaded.Matrix
 
   @spec surround_matrix(Matrix.t(), integer(), integer()) :: Matrix.t()
+  def surround_matrix(matrix, 0, _value), do: matrix
+
   def surround_matrix(matrix, quiet_zone, value)
-      when is_integer(quiet_zone) and quiet_zone >= 0 do
-    # If quiet_zone is 0, just return the original matrix
-    if quiet_zone == 0 do
-      matrix
-    else
-      {rows, cols} = Matrix.size(matrix)
+      when is_integer(quiet_zone) and quiet_zone > 0 do
+    {rows, cols} = Matrix.size(matrix)
 
-      # Create new matrix with quiet zone
-      {:ok, new_matrix} = Matrix.new({rows + 2 * quiet_zone, cols + 2 * quiet_zone}, value)
+    # Create new matrix with quiet zone
+    {:ok, new_matrix} = Matrix.new({rows + 2 * quiet_zone, cols + 2 * quiet_zone}, value)
 
-      # Copy qr code matrix to new matrix
-      {:ok, new_matrix} = Matrix.update_map(new_matrix, matrix, [{quiet_zone, quiet_zone}])
+    # Copy qr code matrix to new matrix
+    {:ok, new_matrix} = Matrix.update_map(new_matrix, matrix, [{quiet_zone, quiet_zone}])
 
-      new_matrix
-    end
+    new_matrix
   end
 end

--- a/lib/qr_code/matrix_helper.ex
+++ b/lib/qr_code/matrix_helper.ex
@@ -7,14 +7,19 @@ defmodule QRCode.MatrixHelper do
   @spec surround_matrix(Matrix.t(), integer(), integer()) :: Matrix.t()
   def surround_matrix(matrix, quiet_zone, value)
       when is_integer(quiet_zone) and quiet_zone >= 0 do
-    {rows, cols} = Matrix.size(matrix)
+    # If quiet_zone is 0, just return the original matrix
+    if quiet_zone == 0 do
+      matrix
+    else
+      {rows, cols} = Matrix.size(matrix)
 
-    # Create new matrix with quiet zone
-    {:ok, new_matrix} = Matrix.new({rows + 2 * quiet_zone, cols + 2 * quiet_zone}, value)
+      # Create new matrix with quiet zone
+      {:ok, new_matrix} = Matrix.new({rows + 2 * quiet_zone, cols + 2 * quiet_zone}, value)
 
-    # Copy qr code matrix to new matrix
-    {:ok, new_matrix} = Matrix.update_map(new_matrix, matrix, [{quiet_zone, quiet_zone}])
+      # Copy qr code matrix to new matrix
+      {:ok, new_matrix} = Matrix.update_map(new_matrix, matrix, [{quiet_zone, quiet_zone}])
 
-    new_matrix
+      new_matrix
+    end
   end
 end

--- a/test/svg_test.exs
+++ b/test/svg_test.exs
@@ -211,19 +211,19 @@ defmodule SvgTest do
 
       # The surrounded matrix should have white (0) borders
       # Check first row is all zeros (white margin)
-      first_row = matrix_with_quiet_1 |> List.first()
+      first_row = List.first(matrix_with_quiet_1)
       assert Enum.all?(first_row, &(&1 == 0))
 
       # Check last row is all zeros (white margin)
-      last_row = matrix_with_quiet_1 |> List.last()
+      last_row = List.last(matrix_with_quiet_1)
       assert Enum.all?(last_row, &(&1 == 0))
 
       # Check first column is all zeros (white margin)
-      first_col = matrix_with_quiet_1 |> Enum.map(&List.first/1)
+      first_col = Enum.map(matrix_with_quiet_1, &List.first/1)
       assert Enum.all?(first_col, &(&1 == 0))
 
       # Check last column is all zeros (white margin)
-      last_col = matrix_with_quiet_1 |> Enum.map(&List.last/1)
+      last_col = Enum.map(matrix_with_quiet_1, &List.last/1)
       assert Enum.all?(last_col, &(&1 == 0))
     end
   end

--- a/test/svg_test.exs
+++ b/test/svg_test.exs
@@ -152,7 +152,7 @@ defmodule SvgTest do
       assert Regex.match?(@rgx_qr_color, rv)
     end
 
-    test "should render svg with no margin when quiet_zone is 0" do
+    test "render svg with no margin when quiet_zone is 0" do
       {:ok, qr} = QRCode.create("A")  # Simple QR code for predictable size
 
       # Get the original matrix size
@@ -183,6 +183,48 @@ defmodule SvgTest do
       expected_size_with_margin = (rows + 2) * 10
       assert svg_with_margin =~ ~r/width="#{expected_size_with_margin}"/
       assert svg_with_margin =~ ~r/height="#{expected_size_with_margin}"/
+    end
+
+    test "render svg with 1-unit margin when quiet_zone is 1" do
+      {:ok, qr} = QRCode.create("A")  # Simple QR code for predictable size
+
+      # Get the original matrix size
+      {rows, cols} = MatrixReloaded.Matrix.size(qr.matrix)
+
+      # Render with quiet_zone: 1 and scale: 10
+      {:ok, svg_content} =
+        QRCode.render({:ok, qr}, :svg, %SvgSettings{quiet_zone: 1, scale: 10, structure: :readable})
+
+      # The SVG dimensions should be matrix size + 2 units (1 on each side) * scale
+      expected_size = (rows + 2) * 10
+      assert svg_content =~ ~r/width="#{expected_size}"/
+      assert svg_content =~ ~r/height="#{expected_size}"/
+
+      # With 1-unit margin, the first QR rectangles should start at x="10" and y="10" (not x="0")
+      # because there's a 1-unit (10-pixel) margin on each side
+      assert svg_content =~ ~r/x="10"/
+      assert svg_content =~ ~r/y="10"/
+
+      # Verify that MatrixHelper.surround_matrix works with quiet_zone: 1
+      matrix_with_quiet_1 = QRCode.MatrixHelper.surround_matrix(qr.matrix, 1, 0)
+      assert MatrixReloaded.Matrix.size(matrix_with_quiet_1) == {rows + 2, cols + 2}
+
+      # The surrounded matrix should have white (0) borders
+      # Check first row is all zeros (white margin)
+      first_row = matrix_with_quiet_1 |> List.first()
+      assert Enum.all?(first_row, &(&1 == 0))
+
+      # Check last row is all zeros (white margin)
+      last_row = matrix_with_quiet_1 |> List.last()
+      assert Enum.all?(last_row, &(&1 == 0))
+
+      # Check first column is all zeros (white margin)
+      first_col = matrix_with_quiet_1 |> Enum.map(&List.first/1)
+      assert Enum.all?(first_col, &(&1 == 0))
+
+      # Check last column is all zeros (white margin)
+      last_col = matrix_with_quiet_1 |> Enum.map(&List.last/1)
+      assert Enum.all?(last_col, &(&1 == 0))
     end
   end
 end

--- a/test/svg_test.exs
+++ b/test/svg_test.exs
@@ -151,5 +151,38 @@ defmodule SvgTest do
 
       assert Regex.match?(@rgx_qr_color, rv)
     end
+
+    test "should render svg with no margin when quiet_zone is 0" do
+      {:ok, qr} = QRCode.create("A")  # Simple QR code for predictable size
+
+      # Get the original matrix size
+      {rows, cols} = MatrixReloaded.Matrix.size(qr.matrix)
+
+      # Render with quiet_zone: 0 and scale: 10
+      {:ok, svg_content} =
+        QRCode.render({:ok, qr}, :svg, %SvgSettings{quiet_zone: 0, scale: 10, structure: :readable})
+
+      # The SVG dimensions should match exactly the matrix size * scale
+      expected_size = rows * 10
+      assert svg_content =~ ~r/width="#{expected_size}"/
+      assert svg_content =~ ~r/height="#{expected_size}"/
+
+      # There should be rectangles starting at x="0" and y="0" (no margin)
+      assert svg_content =~ ~r/x="0"/
+      assert svg_content =~ ~r/y="0"/
+
+      # Verify that MatrixHelper.surround_matrix works with quiet_zone: 0
+      matrix_with_no_quiet = QRCode.MatrixHelper.surround_matrix(qr.matrix, 0, 0)
+      assert MatrixReloaded.Matrix.size(matrix_with_no_quiet) == {rows, cols}
+
+      # Compare with quiet_zone: 1 to ensure the difference is clear
+      {:ok, svg_with_margin} =
+        QRCode.render({:ok, qr}, :svg, %SvgSettings{quiet_zone: 1, scale: 10, structure: :readable})
+
+      # With quiet_zone: 1, dimensions should be 2 units larger (1 unit margin on each side)
+      expected_size_with_margin = (rows + 2) * 10
+      assert svg_with_margin =~ ~r/width="#{expected_size_with_margin}"/
+      assert svg_with_margin =~ ~r/height="#{expected_size_with_margin}"/
+    end
   end
 end


### PR DESCRIPTION
When the quiet_space setting is zero, there was a margin of one block around the QR image. That's the same margin that is created for the quiet_space=1 case. This PR fixes the quiet_space=0 case so that there is no margin. When quiet_space is 1 or more, then the margin is `quiet_space * block_size`.